### PR TITLE
fix reverse proxy URL

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -6,7 +6,7 @@ module.exports = {
   devServer: {
     proxy: {
       '/api': {
-        target: 'process.env.BASE_URL',
+        target: process.env.VUE_APP_BASE_URL,
         changeOrigin: true,
         pathRewrite: { '^/api': '' }
       },


### PR DESCRIPTION
I've added  VUE_APP_BASE_URL in the URL target in reverse proxy configurations. When I modified the .env file to recognise the token in the Axios file, I changed the BASE_URL to VUE_APP_BASE_URL, but I didn't make these changes in "vue.config". Please check it. Thanks.