### PR TITLE
Adding padding top to the navbar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="bg-gray-900 min-h-screen">
-    <nav-bar/>
-    <router-view/>
+    <nav-bar />
+    <div class="content pt-16">
+      <router-view />
+    </div>
   </div>
 </template>
-

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -40,8 +40,6 @@
       </tool-bar>
     </div>
  
-      <div class="mt-14"></div>
- 
     <div v-if="sidebarVisible" class="fixed top-0 right-0 z-50 flex flex-col bg-gray-800 text-white w-44 max-h-screen overflow-y-auto p-5">
       <div class="flex justify-end">
         <button @click="toggleSideBar" class="focus:outline-none">


### PR DESCRIPTION
I replaced the margin top that I had placed in the navbar, to separate the cards so that they wouldn't be below the navbar, with a padding top in App.vue itself. This way, the spacing will be more appropriate and there will be no possibility of errors. 

Take a look